### PR TITLE
Update privacy policy

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -59,6 +59,7 @@ import "../css/darkmode.css";
     <div class="impressum-container footer-item">
       <a href="/impressum" class="impressum-link">Impressum</a>
       <a href="/datenschutz" class="impressum-link">Datenschutz</a>
+      <button type="button" id="cookie-settings" class="impressum-link">Cookie-Einstellungen</button>
     </div>
   </div>
 </footer>
@@ -270,6 +271,11 @@ import "../css/darkmode.css";
 
   /* Impressum Link */
   .impressum-link {
+    appearance: none;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    font-family: inherit;
     font-size: 0.9rem;
     color: var(--text-primary);
     text-decoration: none;
@@ -419,6 +425,12 @@ import "../css/darkmode.css";
   }
 
   document.addEventListener('DOMContentLoaded', () => {
+    const cookieSettings = document.getElementById('cookie-settings');
+    cookieSettings?.addEventListener('click', () => {
+      localStorage.removeItem('cookie-consent');
+      window.location.href = '/';
+    });
+
     const footer = document.getElementById('page-footer');
     const scrollAction = document.getElementById('scroll-action');
     const scrollText = document.getElementById('scroll-text');

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -136,9 +136,6 @@ const businessData = {
     <!-- Strukturierte Daten für lokales Geschäft -->
     <script type="application/ld+json" set:html={JSON.stringify(businessData)}></script>
 
-    <!-- Font Awesome für Icons -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-    
     <!-- Canonical URL -->
     <link rel="canonical" href={Astro.url} />
   </head>

--- a/src/pages/datenschutz.astro
+++ b/src/pages/datenschutz.astro
@@ -20,54 +20,73 @@ import Nav from "../components/Nav.astro";
         <h1>Datenschutzerklärung</h1>
       </div>
 
+      <p class="privacy-meta">Stand: Juli 2026</p>
+
       <section>
         <h2>1. Datenschutz auf einen Blick</h2>
-        <p>Die folgenden Hinweise geben einen einfachen Überblick darüber, was mit Ihren personenbezogenen Daten passiert, wenn Sie diese Website besuchen. Personenbezogene Daten sind alle Daten, mit denen Sie persönlich identifiziert werden können.</p>
+        <h3>Allgemeine Hinweise</h3>
+        <p>Diese Erklärung informiert Sie darüber, welche personenbezogenen Daten beim Besuch dieser Website verarbeitet werden. Personenbezogene Daten sind Informationen, die sich einer bestimmten oder bestimmbaren Person zuordnen lassen.</p>
+        <h3>Wie werden Daten erhoben?</h3>
+        <p>Technische Daten werden beim Seitenaufruf automatisch durch den Hosting-Dienst verarbeitet. Weitere Angaben erhalten wir, wenn Sie das Kontaktformular verwenden oder uns direkt kontaktieren. Statistikdaten werden nur verarbeitet, wenn Sie zuvor ausdrücklich in die Kategorie „Analyse“ eingewilligt haben.</p>
+        <h3>Wofür werden die Daten genutzt?</h3>
+        <p>Die Verarbeitung dient dem sicheren und fehlerfreien Betrieb der Website, der Bearbeitung Ihrer Anfrage und – nach Einwilligung – der statistischen Auswertung, mit der das Angebot verbessert werden soll.</p>
       </section>
 
       <section>
-        <h2>2. Verantwortlicher</h2>
-        <p>Colin Blome<br />Buten Porten 4<br />49584 Fürstenau<br />E-Mail: info@colinblome.dev</p>
+        <h2>2. Verantwortliche Stelle</h2>
+        <p>Colin Blome<br />Buten Porten 4<br />49584 Fürstenau<br />E-Mail: <a href="mailto:info@colinblome.dev">info@colinblome.dev</a></p>
+        <p>Verantwortliche Stelle ist die Person, die über Zwecke und Mittel der Verarbeitung personenbezogener Daten entscheidet.</p>
       </section>
 
       <section>
-        <h2>3. Datenerfassung auf dieser Website</h2>
-        <h3>Server-Log-Dateien</h3>
-        <p>Der Provider der Seiten erhebt und speichert automatisch Informationen in so genannten Server-Log-Dateien, die Ihr Browser automatisch an uns übermittelt. Dies sind z.B. Browsertyp, Betriebssystem, Referrer-URL, Hostname des zugreifenden Rechners, Uhrzeit der Serveranfrage und IP-Adresse. Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht vorgenommen.</p>
-
-        <h3>Kontaktformular</h3>
-        <p>Wenn Sie uns per Kontaktformular Anfragen zukommen lassen, werden Ihre Angaben aus dem Anfrageformular inklusive der von Ihnen dort angegebenen Kontaktdaten zwecks Bearbeitung der Anfrage und für den Fall von Anschlussfragen bei uns gespeichert.</p>
-        <p><strong>Technische Verarbeitung durch Netlify:</strong> Die Datenverarbeitung erfolgt über den Dienst "Netlify Forms" (Netlify, Inc., 2325 3rd Street, Suite 296, San Francisco, CA 94107, USA). Netlify fungiert hierbei als Auftragsverarbeiter im Sinne des Art. 28 DSGVO. Die übermittelten Daten werden auf Servern von Netlify in den USA gespeichert und verarbeitet.</p>
-        <p><strong>Rechtsgrundlage:</strong> Art. 6 Abs. 1 lit. b DSGVO (Verarbeitung zur Erfüllung vorvertraglicher Maßnahmen bzw. zur Bearbeitung Ihrer Anfrage) sowie Ihre ausdrückliche Einwilligung gemäß Art. 6 Abs. 1 lit. a DSGVO.</p>
-        <p><strong>Datentransfer in Drittland:</strong> Die Datenübermittlung in die USA erfolgt auf Grundlage der Standardvertragsklauseln der EU-Kommission. Netlify hat sich zudem dem EU-US Data Privacy Framework angeschlossen.</p>
-        <p><strong>Speicherdauer:</strong> Ihre Daten werden gelöscht, sobald sie für den Zweck ihrer Erhebung nicht mehr erforderlich sind, spätestens jedoch 3 Jahre nach Erledigung Ihrer Anfrage, sofern keine gesetzlichen Aufbewahrungspflichten bestehen.</p>
-        <p><strong>Ihre Rechte:</strong> Sie haben jederzeit das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit und Widerspruch. Zur Ausübung dieser Rechte oder zum Widerruf erteilter Einwilligungen wenden Sie sich bitte an info@colinblome.dev. Sie haben zudem das Recht, sich bei einer Aufsichtsbehörde zu beschweren.</p>
-        <p><strong>Weitere Informationen:</strong> Detaillierte Informationen zur Datenverarbeitung durch Netlify finden Sie in deren Datenschutzerklärung: <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener">https://www.netlify.com/privacy/</a></p>
+        <h2>3. Hosting durch Netlify</h2>
+        <p>Diese Website wird über Netlify bereitgestellt. Anbieter ist Netlify, Inc., 101 2nd Street, San Francisco, CA 94105, USA. Beim Abruf der Website verarbeitet Netlify insbesondere Ihre IP-Adresse, Datum und Uhrzeit, die aufgerufene Ressource, Referrer-Informationen sowie Angaben zu Browser, Betriebssystem und Endgerät in Server-Protokollen.</p>
+        <p>Die Verarbeitung ist erforderlich, um die Website zuverlässig, schnell und sicher auszuliefern. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO; soweit der Besuch der Anbahnung oder Erfüllung eines Vertrags dient, zusätzlich Art. 6 Abs. 1 lit. b DSGVO. Mit Netlify wird die Verarbeitung im Auftrag nach Art. 28 DSGVO geregelt.</p>
+        <p>Daten können auch in den USA verarbeitet werden. Netlify beruft sich für Übermittlungen unter anderem auf die EU-Standardvertragsklauseln und ist nach dem EU-US Data Privacy Framework zertifiziert. Weitere Informationen: <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer">Datenschutzerklärung von Netlify</a>.</p>
       </section>
 
       <section>
-        <h2>4. Cookies</h2>
-        <p>Unsere Internetseiten verwenden teilweise so genannte Cookies. Cookies richten auf Ihrem Rechner keinen Schaden an und enthalten keine Viren. Sie dienen dazu, unser Angebot nutzerfreundlicher, effektiver und sicherer zu machen. Sie können Ihren Browser so einstellen, dass Sie über das Setzen von Cookies informiert werden und Cookies nur im Einzelfall erlauben, die Annahme von Cookies für bestimmte Fälle oder generell ausschließen sowie das automatische Löschen der Cookies beim Schließen des Browsers aktivieren.</p>
+        <h2>4. Allgemeine Hinweise zur Verarbeitung</h2>
+        <h3>Speicherdauer</h3>
+        <p>Sofern nachfolgend keine besondere Frist genannt ist, speichern wir personenbezogene Daten nur so lange, wie sie für den jeweiligen Zweck erforderlich sind. Danach werden sie gelöscht, es sei denn, gesetzliche Aufbewahrungspflichten oder die Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen erfordern eine längere Speicherung.</p>
+        <h3>Empfänger</h3>
+        <p>Daten erhalten nur Stellen, die sie für die genannten Zwecke benötigen. Dienstleister werden – soweit erforderlich – auf Grundlage eines Vertrags zur Auftragsverarbeitung eingesetzt. Eine Weitergabe erfolgt außerdem, wenn sie gesetzlich vorgeschrieben ist oder Sie eingewilligt haben.</p>
+        <h3>Widerruf und Widerspruch</h3>
+        <p>Eine Einwilligung können Sie jederzeit mit Wirkung für die Zukunft widerrufen. Beruht eine Verarbeitung auf Art. 6 Abs. 1 lit. f DSGVO, können Sie aus Gründen, die sich aus Ihrer besonderen Situation ergeben, nach Art. 21 DSGVO widersprechen. Die bis zum Widerruf erfolgte Verarbeitung bleibt rechtmäßig.</p>
+        <h3>SSL-/TLS-Verschlüsselung</h3>
+        <p>Die Website wird verschlüsselt über HTTPS übertragen. Dadurch werden Inhalte auf dem Transportweg vor unbefugtem Mitlesen geschützt. Ein vollständiger Schutz jeder Internetübertragung kann dennoch nicht garantiert werden.</p>
       </section>
 
       <section>
-        <h2>5. Google-Dienste</h2>
-        <h3>Google Analytics</h3>
-        <p>Diese Website nutzt Funktionen des Webanalysedienstes Google Analytics. Anbieter ist die Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland. Google Analytics verwendet so genannte "Cookies". Die durch den Cookie erzeugten Informationen über Ihre Benutzung dieser Website werden in der Regel an einen Server von Google in den USA übertragen und dort gespeichert. Die Speicherung von Google-Analytics-Cookies erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Der Websitebetreiber hat ein berechtigtes Interesse an der Analyse des Nutzerverhaltens, um sowohl sein Webangebot als auch seine Werbung zu optimieren.</p>
-        <p>Mehr Informationen zum Umgang mit Nutzerdaten bei Google Analytics finden Sie in der Datenschutzerklärung von Google: <a href="https://support.google.com/analytics/answer/6004245?hl=de" target="_blank" rel="noopener">https://support.google.com/analytics/answer/6004245?hl=de</a></p>
-
-        <h3>Google Tag Manager</h3>
-        <p>Diese Website verwendet den Google Tag Manager. Durch dieses Tool können Website-Tags über eine Oberfläche verwaltet werden. Der Tag Manager selbst (der die Tags implementiert) verarbeitet keine personenbezogenen Daten der Nutzer. Weitere Informationen finden Sie in den Nutzungsrichtlinien von Google: <a href="https://business.safety.google/privacy" target="_blank" rel="noopener">https://business.safety.google/privacy</a></p>
+        <h2>5. Kontaktformular und Kontaktaufnahme</h2>
+        <p>Bei einer Anfrage über das Kontaktformular verarbeiten wir die von Ihnen eingegebenen Angaben, insbesondere Name, E-Mail-Adresse und Nachricht. Die Übermittlung und technische Verarbeitung des Formulars erfolgt über Netlify Forms. Netlify verarbeitet die Angaben dabei als Auftragsverarbeiter; eine Verarbeitung in den USA ist möglich.</p>
+        <p>Die Daten werden verwendet, um Ihre Anfrage zu prüfen, zu beantworten und mögliche Anschlussfragen zu bearbeiten. Geht es um ein Angebot oder einen Auftrag, ist Art. 6 Abs. 1 lit. b DSGVO die Rechtsgrundlage. In sonstigen Fällen beruht die Verarbeitung auf unserem berechtigten Interesse an der sachgerechten Beantwortung von Anfragen nach Art. 6 Abs. 1 lit. f DSGVO. Eine zusätzlich abgefragte Einwilligung stützt sich auf Art. 6 Abs. 1 lit. a DSGVO.</p>
+        <p>Die Angaben werden gelöscht, wenn die Anfrage abschließend erledigt ist und keine gesetzlichen Aufbewahrungspflichten oder berechtigten Gründe für eine weitere Speicherung bestehen. Für eine direkte Kontaktaufnahme per E-Mail gelten diese Grundsätze entsprechend.</p>
       </section>
 
       <section>
-        <h2>6. Ihre Rechte</h2>
-        <p>Sie haben jederzeit das Recht auf unentgeltliche Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der Datenverarbeitung sowie ein Recht auf Berichtigung, Sperrung oder Löschung dieser Daten. Hierzu sowie zu weiteren Fragen zum Thema Datenschutz können Sie sich jederzeit unter der im Impressum angegebenen Adresse an uns wenden.</p>
+        <h2>6. Cookies und lokaler Speicher</h2>
+        <p>Diese Website verwendet Local Storage, um Ihre Datenschutzentscheidung sowie die von Ihnen gewählte Darstellung und Leistungsoptionen zu speichern. Dafür werden die Schlüssel <code>cookie-consent</code>, <code>theme</code> und <code>performance-mode</code> genutzt. Die Informationen bleiben auf Ihrem Endgerät, bis Sie sie über die Browser-Einstellungen löschen.</p>
+        <p>Diese Speicherzugriffe sind für die von Ihnen angeforderten Einstellungen erforderlich. Sie erfolgen nach § 25 Abs. 2 Nr. 2 TDDDG; die anschließende Verarbeitung stützt sich auf Art. 6 Abs. 1 lit. f DSGVO. Optionale Analyse-Technologien werden erst nach Ihrer Einwilligung gemäß § 25 Abs. 1 TDDDG und Art. 6 Abs. 1 lit. a DSGVO aktiviert.</p>
       </section>
 
       <section>
-        <h2>7. Widerspruch gegen Werbe-Mails</h2>
-        <p>Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten Kontaktdaten zur Übersendung von nicht ausdrücklich angeforderter Werbung und Informationsmaterialien wird hiermit widersprochen. Die Betreiber der Seiten behalten sich ausdrücklich rechtliche Schritte im Falle der unverlangten Zusendung von Werbeinformationen, etwa durch Spam-E-Mails, vor.</p>
+        <h2>7. Google Analytics 4 und Google Tag Manager</h2>
+        <p>Nach Ihrer Zustimmung zu Analyse-Technologien nutzt diese Website Google Analytics 4 und den Google Tag Manager. Anbieter in Europa ist Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland; eine Verarbeitung durch Google LLC in den USA kann nicht ausgeschlossen werden.</p>
+        <p>Google Analytics verarbeitet abhängig von der Konfiguration insbesondere Seitenaufrufe, Interaktionen, technische Browser- und Geräteinformationen, Referrer-Daten sowie ungefähre Standortinformationen. Die IP-Adresse wird bei Google Analytics 4 zur Ableitung grober Standortdaten verwendet und nach Angaben von Google verworfen, bevor sie protokolliert wird. Google-Signale und personalisierte Werbung sind in der lokalen Konfiguration deaktiviert.</p>
+        <p>Der Google Tag Manager dient dazu, Website-Tags zentral zu verwalten. Beim Laden wird bereits eine Verbindung zu Google aufgebaut; welche weitere Verarbeitung stattfindet, hängt von den eingebundenen Tags ab. Beide Dienste werden deshalb erst nach Ihrer Einwilligung geladen. Rechtsgrundlagen sind Art. 6 Abs. 1 lit. a DSGVO und § 25 Abs. 1 TDDDG.</p>
+        <p>Von uns konfigurierbare nutzer- und ereignisbezogene Analytics-Daten werden spätestens nach 14 Monaten gelöscht. Ihre Einwilligung können Sie jederzeit über „Cookie-Einstellungen“ im Footer widerrufen. Google ist nach dem EU-US Data Privacy Framework zertifiziert; ergänzend können Standardvertragsklauseln eingesetzt werden. Weitere Informationen: <a href="https://policies.google.com/privacy?hl=de" target="_blank" rel="noopener noreferrer">Datenschutzerklärung von Google</a>.</p>
+      </section>
+
+      <section>
+        <h2>8. Ihre Rechte</h2>
+        <p>Nach Maßgabe der gesetzlichen Voraussetzungen haben Sie insbesondere das Recht auf Auskunft (Art. 15 DSGVO), Berichtigung (Art. 16 DSGVO), Löschung (Art. 17 DSGVO), Einschränkung der Verarbeitung (Art. 18 DSGVO), Datenübertragbarkeit (Art. 20 DSGVO) und Widerspruch (Art. 21 DSGVO).</p>
+        <p>Zur Ausübung Ihrer Rechte genügt eine Nachricht an <a href="mailto:info@colinblome.dev">info@colinblome.dev</a>. Außerdem können Sie sich nach Art. 77 DSGVO bei einer Datenschutzaufsichtsbehörde beschweren. Für den Sitz in Niedersachsen ist insbesondere der <a href="https://www.lfd.niedersachsen.de/" target="_blank" rel="noopener noreferrer">Landesbeauftragte für den Datenschutz Niedersachsen</a>, Prinzenstraße 5, 30159 Hannover, zuständig.</p>
+      </section>
+
+      <section>
+        <h2>9. Aktualität</h2>
+        <p>Diese Datenschutzerklärung hat den Stand Juli 2026. Sie wird angepasst, wenn sich eingesetzte Dienste, technische Abläufe oder rechtliche Anforderungen ändern.</p>
       </section>
     </div>
   </main>
@@ -155,6 +174,27 @@ import Nav from "../components/Nav.astro";
   p {
     line-height: 1.6;
     margin-bottom: 0.75rem;
+  }
+  .privacy-meta {
+    color: var(--text-primary);
+    opacity: 0.7;
+    text-align: center;
+    margin: -1rem 0 2.5rem;
+  }
+  section a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+  }
+  section ul {
+    margin: 0.75rem 0 1rem 1.25rem;
+  }
+  section li {
+    line-height: 1.6;
+    margin-bottom: 0.35rem;
+  }
+  section code {
+    color: var(--accent);
   }
   section {
     margin-bottom: 2rem;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,31 +29,6 @@ const hasCookieConsent = false; // Dies wird clientseitig überprüft
       // Kein dupliziertes Scroll-Blocking hier
     </script>
 
-    <!-- Google Tag Manager -->
-    <script is:inline>
-      // TypeScript-sicherer GTM-Code
-      (function (w, d, s, l, i) {
-        var f, j;
-        (w[l] = w[l] || []).push({
-          "gtm.start": new Date().getTime(),
-          event: "gtm.js",
-        });
-        f = d.getElementsByTagName(s)[0];
-        j = d.createElement(s);
-        if (j instanceof HTMLScriptElement) {
-          j.async = true;
-          j.src =
-            "https://www.googletagmanager.com/gtm.js?id=" +
-            i +
-            (l !== "dataLayer" ? "&l=" + l : "");
-        }
-        if (f && f.parentNode) {
-          f.parentNode.insertBefore(j, f);
-        }
-      })(window, document, "script", "dataLayer", "GTM-WFG6LFSX");
-    </script>
-    <!-- End Google Tag Manager -->
-
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -362,16 +337,6 @@ const hasCookieConsent = false; // Dies wird clientseitig überprüft
   <body
     class="w-full flex-col items-center content-center fadein2 custom-scrollbar"
   >
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-WFG6LFSX"
-        height="0"
-        width="0"
-        style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
-
     <!-- SEO-optimierte versteckte Überschrift für Suchmaschinen -->
     <h1 class="seo-hidden">
       CB-WebDev | Webentwicklung Fürstenau | Webseite kaufen Samtgemeinde


### PR DESCRIPTION
## What changed

- Replaced the privacy policy with an implementation-specific version covering Netlify hosting and forms, local storage, Google Analytics 4, Google Tag Manager, retention, international transfers, and data-subject rights.
- Removed the unconditional GTM load so analytics starts only after consent.
- Added a footer control to reopen cookie settings.
- Removed the redundant external cdnjs Font Awesome stylesheet.

## Why

The previous policy was incomplete and did not fully match the website's actual data processing. GTM also loaded before consent despite the banner logic.

## Impact

Visitors receive more complete privacy information, and optional analytics now follows the documented consent flow.

## Checks

- `npm run build`
- `git diff --check`
